### PR TITLE
reload time as soon as possible

### DIFF
--- a/systemd/fake-hwclock.service
+++ b/systemd/fake-hwclock.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Fake Hardware Clock
-After=dbus.service
+Documentation=man:fake-hwclock(8)
+DefaultDependencies=no
+Before=sysinit.target
 
 [Service]
 Type=forking
@@ -11,4 +13,4 @@ RemainAfterExit=yes
 User=root
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target


### PR DESCRIPTION
I pushed the same in Debian/Raspbian.

https://github.com/a-detiste/fake-hwclock/blob/master/debian/fake-hwclock.service

Reloading the clock doesn't even need a read-write root fs,
this can happen really soon. ( sysinit.target is roughly equivalent to runlevel "S")
