### PR TITLE
add systemd timer to avoid cron

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ TARGET = fake-hwclock
 SOURCES = fake-hwclock.c
 PREFIX = $(DESTDIR)/usr
 BINDIR = $(PREFIX)/bin
-
+INIT = $(PREFIX)/lib/systemd/system
+DOCS = $(PREFIX)/share/man/man8
 all: $(TARGET)
 
 $(TARGET):
@@ -10,5 +11,11 @@ $(TARGET):
 
 install:
 	install -D $(TARGET) $(BINDIR)/$(TARGET)
+	install -d $(INIT)
+	install -m644 systemd/$(TARGET).service $(INIT)/$(TARGET).service
+	install -m644 systemd/$(TARGET).timer $(INIT)/$(TARGET).timer
+	gzip -9 man/$(TARGET).8
+	install -d $(DOCS)
+	install -m644 man/$(TARGET).8.gz $(DOCS)/$(TARGET).8.gz
 
 .PHONY: install

--- a/README.md
+++ b/README.md
@@ -20,20 +20,17 @@ Please follow the instructions from https://wiki.archlinux.org/index.php/Arch_Us
 Installation (not using AUR)
 ----------------------------
 
-Suggested packages: `ntp` and `cron`.
+Suggested packages: `ntp` and `cron` or enable `systemd-timesyncd`
 
 	make
 	make install
 
 
-To set system time on start up and save system time on halt, enable the systemd service:
+To set system time on start up and save system time on halt as well as run every 15 min,  enable the systemd service:
 
-	systemctl enable fake-hwclock.service
+	systemctl enable fake-hwclock
 
-
-To keep `fake-hwclock` up to date in case of power failure, install and enable `ntp` and add the following job to your root `crontab` (`sudo crontab -e`):
-
-	*/15 * * * * /usr/bin/fake-hwclock
+This will also activate a systemd timer unit that will run every 15 min.
 
 
 

--- a/systemd/fake-hwclock.service
+++ b/systemd/fake-hwclock.service
@@ -4,12 +4,11 @@ Documentation=man:fake-hwclock(8)
 DefaultDependencies=no
 Before=systemd-journald.service
 Conflicts=shutdown.target
+Wants=fake-hwclock.timer
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/bin/fake-hwclock
-ExecStop=/usr/bin/fake-hwclock
-RemainAfterExit=yes
 
 [Install]
 WantedBy=local-fs-pre.target

--- a/systemd/fake-hwclock.timer
+++ b/systemd/fake-hwclock.timer
@@ -1,0 +1,6 @@
+[Unit]
+Description=Update fake hardware clock time
+PartOf=fake-hwclock.service
+
+[Timer]
+OnUnitActiveSec=15m


### PR DESCRIPTION
Great job with this software.  The PR provides a timer that is enabled when the service is enabled.  There is no need to use cron.  As well, since you are targeting Arch ARM, I see no reason not to provide the systemd units and man page to the Arch default locations.