### PR TITLE
fix systemd service unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ install:
 	install -D $(TARGET) $(BINDIR)/$(TARGET)
 	install -d $(INIT)
 	install -m644 systemd/$(TARGET).service $(INIT)/$(TARGET).service
-	install -m644 systemd/$(TARGET).timer $(INIT)/$(TARGET).timer
+	install -m644 systemd/$(TARGET)-checkin.service $(INIT)/$(TARGET)-checkin.service
+	install -m644 systemd/$(TARGET)-checkin.timer $(INIT)/$(TARGET)-checkin.timer
 	gzip -9 man/$(TARGET).8
 	install -d $(DOCS)
 	install -m644 man/$(TARGET).8.gz $(DOCS)/$(TARGET).8.gz

--- a/systemd/fake-hwclock-checkin.service
+++ b/systemd/fake-hwclock-checkin.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Timed update of fake-hwclock
+After=fake-hwclock.service
+Wants=fake-hwclock-checkin.timer
+PartOf=fake-hwclock.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/fake-hwclock
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/fake-hwclock-checkin.timer
+++ b/systemd/fake-hwclock-checkin.timer
@@ -1,6 +1,6 @@
 [Unit]
 Description=Update fake hardware clock time
-PartOf=fake-hwclock.service
+PartOf=fake-hwclock.service fake-hwclock-checkin.service
 
 [Timer]
 OnUnitActiveSec=15m

--- a/systemd/fake-hwclock.service
+++ b/systemd/fake-hwclock.service
@@ -1,15 +1,13 @@
 [Unit]
 Description=Fake Hardware Clock
 Documentation=man:fake-hwclock(8)
-DefaultDependencies=no
-Before=systemd-journald.service
-Conflicts=shutdown.target
-Wants=fake-hwclock.timer
+Wants=fake-hwclock-checkin.service
 
 [Service]
-Type=simple
-ExecStart=/usr/bin/fake-hwclock
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/true
 ExecStop=/usr/bin/fake-hwclock
 
 [Install]
-WantedBy=local-fs-pre.target
+WantedBy=sysinit.target


### PR DESCRIPTION
Running as type=simple does not run on shutdown and results in lost time.  With type=oneshot, it does run on shutdown.