### PR TITLE
Improve support for cross compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+fake-hwclock

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ PREFIX = $(DESTDIR)/usr
 BINDIR = $(PREFIX)/bin
 INIT = $(PREFIX)/lib/systemd/system
 DOCS = $(PREFIX)/share/man/man8
+CC ?= gcc
 all: $(TARGET)
 
 $(TARGET):
-	gcc -o $(TARGET) $(SOURCES)
+	$(CC) -o $(TARGET) $(SOURCES)
 
 install:
 	install -D $(TARGET) $(BINDIR)/$(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ install:
 	install -m644 man/$(TARGET).8.gz $(DOCS)/$(TARGET).8.gz
 
 clean:
-	rm $(TARGET)
+	rm -f $(TARGET)
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TARGET = fake-hwclock
 SOURCES = fake-hwclock.c
-PREFIX = $(DESTDIR)/usr
+PREFIX ?= $(DESTDIR)/usr
 BINDIR = $(PREFIX)/bin
 INIT = $(PREFIX)/lib/systemd/system
 DOCS = $(PREFIX)/share/man/man8
@@ -18,5 +18,8 @@ install:
 	gzip -9 man/$(TARGET).8
 	install -d $(DOCS)
 	install -m644 man/$(TARGET).8.gz $(DOCS)/$(TARGET).8.gz
+
+clean:
+	rm $(TARGET)
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 	install -d $(INIT)
 	install -m644 systemd/$(TARGET).service $(INIT)/$(TARGET).service
 	install -m644 systemd/$(TARGET).timer $(INIT)/$(TARGET).timer
-	gzip -9 man/$(TARGET).8
+	gzip --force --keep -9 man/$(TARGET).8
 	install -d $(DOCS)
 	install -m644 man/$(TARGET).8.gz $(DOCS)/$(TARGET).8.gz
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@ BINDIR = $(PREFIX)/bin
 INIT = $(PREFIX)/lib/systemd/system
 DOCS = $(PREFIX)/share/man/man8
 CC ?= gcc
+LDFLAGS ?= 
 all: $(TARGET)
 
 $(TARGET):
-	$(CC) -o $(TARGET) $(SOURCES)
+	$(CC) -o $(TARGET) $(SOURCES) $(LDFLAGS)
 
 install:
 	install -D $(TARGET) $(BINDIR)/$(TARGET)

--- a/fake-hwclock.c
+++ b/fake-hwclock.c
@@ -9,10 +9,17 @@
  * and reset it. */
 static time_t max_diff = 60 * 60 * 24 * 365 * 10; /* ten years */
 
-int main (int argc, char *argv[]) 
+int main (int argc, char *argv[])
 {
 	struct stat temp;
-	const char *timefile = argv[0];
+	const char *timefile;
+	/* The time is stored in the creation and modification date of a file.
+	 * If no specific file is passed, use the executable itself.
+	 */
+	if (argc > 1)
+		timefile = argv[1];
+	else
+		timefile = argv[0];
 	time_t current_time;
 	time_t time_store;
 	time_t diff;

--- a/systemd/fake-hwclock.service
+++ b/systemd/fake-hwclock.service
@@ -2,7 +2,6 @@
 Description=Fake Hardware Clock
 Documentation=man:fake-hwclock(8)
 DefaultDependencies=no
-Before=systemd-journald.service
 Conflicts=shutdown.target
 Wants=fake-hwclock.timer
 

--- a/systemd/fake-hwclock.service
+++ b/systemd/fake-hwclock.service
@@ -12,4 +12,4 @@ ExecStart=/usr/bin/fake-hwclock
 ExecStop=/usr/bin/fake-hwclock
 
 [Install]
-WantedBy=local-fs-pre.target
+WantedBy=multi-user.target

--- a/systemd/fake-hwclock.service
+++ b/systemd/fake-hwclock.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/fake-hwclock
 ExecStop=/usr/bin/fake-hwclock
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=basic.target


### PR DESCRIPTION
When cross compiling, usually the normal gcc cannot be used. The CC
variable can be used to specify a different C compiler. Keep gcc as the
default in case nothing is specified.